### PR TITLE
Sane https

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,11 @@
 language: node_js
 node_js:
-  - "0.8"
-  - "0.10"
+  - "iojs-v3"
+  - "iojs-v2"
+  - "iojs-v1"
   - "0.12"
-  - "iojs"
+  - "0.10"
+  - "0.8"
 before_install:
   - 'if [ "${TRAVIS_NODE_VERSION}" == "0.8" ] ; then npm install -g npm@2.7.0; fi'
 script:

--- a/README.md
+++ b/README.md
@@ -57,6 +57,12 @@ The following properties can be provided as callback object:
 - **http**: A new HTTP server has been created.
 - **spdy**: A new SPDY server has been created.
 
+When creating a secure server, we will do our best to provide sane defaults that
+will protect your server against known secure server attacks such as POODLE, we
+also update the cipher list to prevent attacks such as heart bleed. This can be
+overridden by supplying your own `cypher`, `secureProtocol` and `secureOptions`
+keys as option.
+
 ## License
 
 MIT

--- a/package.json
+++ b/package.json
@@ -32,11 +32,11 @@
     "connected": "0.0.x"
   },
   "devDependencies": {
-    "assume": "1.1.x",
+    "assume": "1.2.x",
     "istanbul": "0.3.x",
-    "mocha": "2.1.x",
-    "pre-commit": "1.0.x",
-    "request": "2.53.x",
-    "spdy": "1.31.x"
+    "mocha": "2.2.x",
+    "pre-commit": "1.1.x",
+    "request": "2.61.x",
+    "spdy": "2.0.x"
   }
 }


### PR DESCRIPTION
I found out that we're not providing any sane HTTPS default options by default. While this would affect IE6 users because SSLv2 will no longer be supported by it, it will create a more secure connection for the rest of the world. As this is a major breaking change, Primus and this module should receive a major bump.